### PR TITLE
Paginate refile errors page SCC-1128

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,40 +3,28 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.5.1'
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.0'
-# Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
-# Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
+gem 'faraday'
+gem 'coffee-rails', '~> 4.2'
+gem 'aws-sdk-sqs', '~> 1.3'
+gem 'design-toolkit', :git => 'https://github.com/NYPL/design-toolkit.git'
+gem 'bootsnap', '>= 1.1.0', require: false
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
-gem 'faraday'
-# Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.2'
-# use aws-sdk-sqs for talking to amazon sqs
-gem 'aws-sdk-sqs', '~> 1.3'
-# use nypl design toolkit for look and feel
-gem 'design-toolkit', :git => 'https://github.com/NYPL/design-toolkit.git'
-
-# Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.1.0', require: false
-
-# Use OAuth2 for OAuth authentication
 gem 'oauth2'
 
 group :development, :test do
-  gem 'pry'
+  gem 'pry-remote'
   gem 'rubycop'
   gem 'rspec'
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 
 group :development do
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'uglifier', '>= 1.3.0'
 gem 'faraday'
 gem 'coffee-rails', '~> 4.2'
 gem 'aws-sdk-sqs', '~> 1.3'
+
+# Used in asset pipeline for styling
 gem 'design-toolkit', :git => 'https://github.com/NYPL/design-toolkit.git'
 gem 'bootsnap', '>= 1.1.0', require: false
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,9 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     rack (2.0.5)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -181,6 +184,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -221,7 +225,7 @@ DEPENDENCIES
   faraday
   listen (>= 3.0.5, < 3.2)
   oauth2
-  pry
+  pry-remote
   rails (~> 5.2.0)
   rspec
   rubycop

--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ _With the stack running..._
 1.  `docker-compose exec webapp bash` (brings you onto the running container)
 1.  `su app`, `cd ~/scsbuster && bundle exec rails c` (in container)
 
-### Debugging With Pry
+### Debugging With Pry Remote
 
-TODO: Fill this out
+1.  `docker-compose exec webapp bash` (brings you onto the running container)
+1.  In code, add your breakpoint with `binding.pry_remote`, hit the endpoint
+1.  `su app`, `cd ~/scsbuster && bundle exec pry-remote` (in container)
 
 ## Git Workflow & Deployment
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,19 +2,23 @@ class ItemsController < OauthController
   before_action :authenticate
 
   def refile
-    @refile_request = RefileRequest.new
-    # TODO: Finish this in subsequent branch.
+
     if params[:page] && params[:per_page]
       @offset = ( params[:page].to_i - 1 ) * params[:per_page].to_i
     else
       @offset = 0
     end
 
-    date_start = params[:date_start].present? ? params[:date_start] : nil
-    date_end = params[:date_end].present? ? params[:date_end] : nil
-    @refiles = get_refiles(date_start,date_end,params[:page],params[:per_page])
+    @refile_request = RefileRequest.new(
+      date_start: params[:date_start],
+      date_end: params[:date_end],
+      page: params[:page],
+      per_page: params[:per_page]
+    )
+
+    @refiles = @refile_request.get_refiles
   end
-  
+
   def update_metadata
     @barcodes = params[:barcodes] ||= []
     @protect_cgd = params[:protect_cgd]
@@ -68,16 +72,7 @@ class ItemsController < OauthController
     else
       flash[:errors] = "The system encountered an issue. Please retry your submission. If the problem persists, please contact the Digital team at scctech@nypl.org."
     end
-    redirect_to action: 'transfer_metadata', barcode: invalid_barcode, bib_record_number: invalid_bib_record_number, protect_cgd: protect_cgd 
+    redirect_to action: 'transfer_metadata', barcode: invalid_barcode, bib_record_number: invalid_bib_record_number, protect_cgd: protect_cgd
   end
-  
-  private
-  
-  def get_refiles(date_start, date_end, page, per_page)
-    @refile_request.date_start = date_start
-    @refile_request.date_end = date_end
-    @refile_request.page = page
-    @refile_request.per_page = per_page
-    @refile_request.get_refiles
-  end
+
 end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,2 +1,48 @@
 module ItemsHelper
+  def refile_pagination(refile_request, refiles)
+    result = ''
+    if refile_request.page != 1
+      result << "<a href='#{previous_page_url(refile_request)}' class='previous-link pointer' role='link' tabindex='0'>Previous</a>"
+    end
+
+    result << "<span class='page-count'>Page #{refile_request.page} of #{total_page_count(refile_request, refiles)}</span>"
+
+    if refile_request.page != total_page_count(refile_request, refiles)
+      result << "<a href='#{next_page_url(refile_request)}' class='next-link pointer' role='link' tabindex='0'>Next</a>"
+    end
+
+    result.html_safe
+  end
+
+  def cardinality_of_current_results(refile_request, refiles)
+    first_one = refile_request.page == 1 ? 1 : ((refile_request.page - 1) * refile_request.per_page) + 1
+    last_one  = refile_request.page == 1 ? refiles['count'] : (first_one + refiles['count']) - 1
+    "#{first_one}-#{last_one}".html_safe
+  end
+
+  private
+
+  def previous_page_url(refile_request)
+    url = request.original_url
+    url.gsub!(/page=*.*/, "page=#{refile_request.page - 1}")
+    url
+  end
+
+  def total_page_count(refile_request, refiles)
+    pages = refiles['totalCount'] / refile_request.per_page
+    pages += 1 if refiles['totalCount'] % refile_request.per_page
+    pages
+  end
+
+  def next_page_url(refile_request)
+    url = request.original_url
+    if url.include?('page=')
+      url.gsub!(/page=*.*/, "page=#{refile_request.page + 1}")
+    else
+      url << '?' unless url.include?('?')
+      url << '&page=2'
+    end
+    url
+  end
+
 end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,43 +1,39 @@
 module ItemsHelper
-  def refile_pagination(refile_request, refiles)
+  def refile_pagination(refile_error_search, refiles)
     result = ''
-    if refile_request.page != 1
-      result << "<a href='#{previous_page_url(refile_request)}' class='previous-link pointer' role='link' tabindex='0'>Previous</a>"
+    if refile_error_search.page != 1
+      result << "<a href='#{previous_page_url(refile_error_search)}' class='previous-link pointer' role='link' tabindex='0'>Previous</a>"
     end
 
-    result << "<span class='page-count'>Page #{refile_request.page} of #{total_page_count(refile_request, refiles)}</span>"
+    result << "<span class='page-count'>Page #{refile_error_search.page} of #{total_page_count(refile_error_search, refiles)}</span>"
 
-    if refile_request.page != total_page_count(refile_request, refiles)
-      result << "<a href='#{next_page_url(refile_request)}' class='next-link pointer' role='link' tabindex='0'>Next</a>"
+    if refile_error_search.page != total_page_count(refile_error_search, refiles)
+      result << "<a href='#{next_page_url(refile_error_search)}' class='next-link pointer' role='link' tabindex='0'>Next</a>"
     end
 
     result.html_safe
   end
 
-  def cardinality_of_current_results(refile_request, refiles)
-    first_one = refile_request.page == 1 ? 1 : ((refile_request.page - 1) * refile_request.per_page) + 1
-    last_one  = refile_request.page == 1 ? refiles['count'] : (first_one + refiles['count']) - 1
+  def cardinality_of_current_results(refile_error_search, refiles)
+    first_one = refile_error_search.page == 1 ? 1 : ((refile_error_search.page - 1) * refile_error_search.per_page) + 1
+    last_one  = refile_error_search.page == 1 ? refiles['count'] : (first_one + refiles['count']) - 1
     "#{first_one}-#{last_one}".html_safe
   end
 
   private
 
-  def previous_page_url(refile_request)
-    url = request.original_url
-    url.gsub!(/page=*.*/, "page=#{refile_request.page - 1}")
-    url
+  def previous_page_url(refile_error_search)
+    request.original_url.gsub(/page=*.*/, "page=#{refile_error_search.page - 1}")
   end
 
-  def total_page_count(refile_request, refiles)
-    pages = refiles['totalCount'] / refile_request.per_page
-    pages += 1 if refiles['totalCount'] % refile_request.per_page
-    pages
+  def total_page_count(refile_error_search, refiles)
+    (refiles['totalCount'] / refile_error_search.per_page.to_f).ceil
   end
 
-  def next_page_url(refile_request)
+  def next_page_url(refile_error_search)
     url = request.original_url
     if url.include?('page=')
-      url.gsub!(/page=*.*/, "page=#{refile_request.page + 1}")
+      url.gsub!(/page=*.*/, "page=#{refile_error_search.page + 1}")
     else
       url << '?' unless url.include?('?')
       url << '&page=2'

--- a/app/models/refile_error_search.rb
+++ b/app/models/refile_error_search.rb
@@ -2,8 +2,8 @@ require 'json'
 require 'net/http'
 require 'uri'
 
-# Model represents NYPL refile api request, both for get and post requests.
-class RefileRequest
+# Model represents a search for RefileErrors
+class RefileErrorSearch
   include ActiveModel::Model
 
   attr_writer :page, :per_page, :date_start,:date_end

--- a/app/models/refile_request.rb
+++ b/app/models/refile_request.rb
@@ -5,7 +5,7 @@ require 'uri'
 # Model represents NYPL refile api request, both for get and post requests.
 class RefileRequest
 
-  attr_accessor :bearer, :page, :per_page, :success, :date_start, :date_end
+  attr_accessor :bearer, :page, :per_page, :date_start, :date_end
 
   # Authorizes the request.
   def assign_bearer

--- a/app/models/refile_request.rb
+++ b/app/models/refile_request.rb
@@ -5,8 +5,9 @@ require 'uri'
 # Model represents NYPL refile api request, both for get and post requests.
 class RefileRequest
   include ActiveModel::Model
-  
-  attr_accessor :bearer, :page, :per_page, :date_start, :date_end
+
+  attr_writer :page, :per_page, :date_start,:date_end
+  attr_accessor :bearer
 
   # Authorizes the request.
   def assign_bearer
@@ -39,17 +40,28 @@ class RefileRequest
     end
   end
 
+  def date_start
+    @date_start || Date.today - 10000
+  end
+
+  def date_end
+    @date_end || Date.today
+  end
+
+  def page
+    @page.present? ? @page.to_i : 1
+  end
+
+  def per_page
+    @per_page.present? ? @per_page.to_i : 25
+  end
+
   def get_refiles
     self.bearer     = self.assign_bearer
-    date_start      = Date.today - 10000 if date_start.blank?
-    date_end        = Date.today if date_end.blank?
     this_start = date_start.strftime('%Y-%m-%d') + 'T00:00:00-00:00'
     this_end = date_end.strftime('%Y-%m-%d') + 'T23:59:59-00:00'
-    page = 1 if page.blank?
-    per_page = 25 if per_page.blank?
     offset = (page - 1) * per_page
     request_string = "#{API_BASE_URL}/recap/refile-errors?createdDate=[#{this_start},#{this_end}]&offset=#{offset}&limit=#{per_page}&includeTotalCount=true"
-    puts request_string
     uri = URI.parse(request_string)
     request = Net::HTTP::Get.new(uri)
     request["Accept"] = "application/json"

--- a/app/models/refile_request.rb
+++ b/app/models/refile_request.rb
@@ -4,7 +4,8 @@ require 'uri'
 
 # Model represents NYPL refile api request, both for get and post requests.
 class RefileRequest
-
+  include ActiveModel::Model
+  
   attr_accessor :bearer, :page, :per_page, :date_start, :date_end
 
   # Authorizes the request.

--- a/app/models/refile_request.rb
+++ b/app/models/refile_request.rb
@@ -1,12 +1,13 @@
+require 'json'
+require 'net/http'
+require 'uri'
+
 # Model represents NYPL refile api request, both for get and post requests.
 class RefileRequest
-  require 'json'
-  require 'net/http'
-  require 'uri'
-  
+
   attr_accessor :bearer, :page, :per_page, :success, :date_start, :date_end
-  
-  # Authorizes the request. 
+
+  # Authorizes the request.
   def assign_bearer
     begin
       uri = URI.parse(OAUTH_TOKEN_URL)
@@ -36,10 +37,8 @@ class RefileRequest
       self.bearer = nil
     end
   end
-  
+
   def get_refiles
-    require 'net/http'
-    require 'uri'
     self.bearer     = self.assign_bearer
     date_start      = Date.today - 10000 if date_start.blank?
     date_end        = Date.today if date_end.blank?

--- a/app/views/items/refile.html.erb
+++ b/app/views/items/refile.html.erb
@@ -15,7 +15,7 @@
 
 <div>
   <% if @refiles["data"].present? %>
-    <p class='display-result-text'>Displaying <%= cardinality_of_current_results(@refile_request, @refiles) %> of <%= @refiles["totalCount"] %> errors from <%= @refile_request.date_start %> to <%= @refile_request.date_end %></p>
+    <p class='display-result-text'>Displaying <%= cardinality_of_current_results(@refile_error_search, @refiles) %> of <%= @refiles["totalCount"] %> errors from <%= @refile_error_search.date_start %> to <%= @refile_error_search.date_end %></p>
 
     <table class="result-table">
       <caption class="hidden">Refile Error Details</caption>
@@ -45,7 +45,7 @@
 
 
     <nav class="nypl-results-pagination">
-      <%= refile_pagination(@refile_request, @refiles) %>
+      <%= refile_pagination(@refile_error_search, @refiles) %>
     </nav>
   <% else %>
     <p><%= @refiles['statusCode'] %></p>

--- a/app/views/items/refile.html.erb
+++ b/app/views/items/refile.html.erb
@@ -5,40 +5,49 @@
 <p>Clear an &quot;in transit&quot; or &quot;checked out&quot; item status in Sierra</p>
 
 <!--  FORM TO TRANSLATE TO RAILS -->
-<!-- <form>
+<!--
+  <form>
   <div class="nypl-text-field ">
   <label for="barcode" id="barcode-label"><span>Barcode</span><span class="nypl-required-field"> Required</span></label>
   <input type="text" value="" id="barcode" name="barcode" aria-required="true" aria-labelledby="barcode-label barcode-status" placeholder="Enter Barcode"/>
-  <span class="nypl-field-status" id="barcode-status" aria-live="assertive" aria-atomic="true">Make sure the item is available in SCSB first</span></div><div class="nypl-submit-button-wrapper"><input type="submit" class="nypl-primary-button" value="Submit"/></div></form></div><div class="" id=""><h3>Refile Errors</h3><p>Enter dates below to see errors for a specific date range</p><form><div class="nypl-name-field nypl-filter-date-field"><div class="recap-admin-date-field "><label for="startDate" id="startDate-label"><span>Start Date</span><span class="nypl-required-field"> Required</span></label><input type="date" value="2018-08-07" id="startDate" name="startDate" aria-required="true" aria-labelledby="startDate-label startDate-status"/><span class="nypl-field-status" id="startDate-status" aria-live="assertive" aria-atomic="true">The start date as the format as MM/DD/YYYY</span></div><span class="date-divider">to</span><div class="recap-admin-date-field "><label for="endDate" id="endDate-label"><span>End Date</span><span class="nypl-required-field"> Required</span></label><input type="date" value="2018-08-08" id="endDate" name="endDate" aria-required="true" aria-labelledby="endDate-label endDate-status"/><span class="nypl-field-status" id="endDate-status" aria-live="assertive" aria-atomic="true">The end date as the format as MM/DD/YYYY</span></div></div><div class="nypl-submit-button-wrapper"><input type="submit" class="nypl-primary-button" value="Submit"/></div></form> -->
-  
-<% if @refiles["data"].present? %>
-<p>Displaying <%= 1 %> to <%= 25 %> of <%= @refiles["totalCount"] %> errors from <%= @refile_request.date_start %> to <%= @refile_request.date_end %></p>
+  <span class="nypl-field-status" id="barcode-status" aria-live="assertive" aria-atomic="true">Make sure the item is available in SCSB first</span></div><div class="nypl-submit-button-wrapper"><input type="submit" class="nypl-primary-button" value="Submit"/></div></form></div><div class="" id=""><h3>Refile Errors</h3><p>Enter dates below to see errors for a specific date range</p><form><div class="nypl-name-field nypl-filter-date-field"><div class="recap-admin-date-field "><label for="startDate" id="startDate-label"><span>Start Date</span><span class="nypl-required-field"> Required</span></label><input type="date" value="2018-08-07" id="startDate" name="startDate" aria-required="true" aria-labelledby="startDate-label startDate-status"/><span class="nypl-field-status" id="startDate-status" aria-live="assertive" aria-atomic="true">The start date as the format as MM/DD/YYYY</span></div><span class="date-divider">to</span><div class="recap-admin-date-field "><label for="endDate" id="endDate-label"><span>End Date</span><span class="nypl-required-field"> Required</span></label><input type="date" value="2018-08-08" id="endDate" name="endDate" aria-required="true" aria-labelledby="endDate-label endDate-status"/><span class="nypl-field-status" id="endDate-status" aria-live="assertive" aria-atomic="true">The end date as the format as MM/DD/YYYY</span></div></div><div class="nypl-submit-button-wrapper"><input type="submit" class="nypl-primary-button" value="Submit"/></div></form>
+-->
 
-<table class="result-table">
-  <caption class="hidden">Refile Error Details</caption>
-  <thead>
-    <tr>
-      <th scope="col">ID</th>
-      <th scope="col">Barcodes</th>
-      <th scope="col">Created Date</th>
-      <th scope="col">Updated Date</th>
-      <th scope="col">AF</th>
-      <th scope="col">NYPL Item?</th>
-    </tr>
-  </thead>
-  <tbody class="result-table-body">
-    <% @refiles["data"].each do |refile| %>
-      <tr>
-        <td><%= refile["id"] %></td>
-        <td><strong><%= refile["itemBarcode"] %></strong></td>
-        <td><%= Date.parse(refile["createdDate"]).strftime("%Y-%m-%d") if refile["createdDate"] %></td>
-        <td><%= Date.parse(refile["updatedDate"]).strftime("%Y-%m-%d") if refile["updatedDate"]  %></td>
-        <td class="af-message"><%= refile["afMessage"].delete('["').delete('"]') if refile["afMessage"].present? %></td>
-        <td>yes<td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-<% else %>
-  <p><%= @refiles['statusCode'] %></p>
-<% end %>
+<div>
+  <% if @refiles["data"].present? %>
+    <p class='display-result-text'>Displaying <%= cardinality_of_current_results(@refile_request, @refiles) %> of <%= @refiles["totalCount"] %> errors from <%= @refile_request.date_start %> to <%= @refile_request.date_end %></p>
+
+    <table class="result-table">
+      <caption class="hidden">Refile Error Details</caption>
+      <thead>
+        <tr>
+          <th scope="col">ID</th>
+          <th scope="col">Barcodes</th>
+          <th scope="col">Created Date</th>
+          <th scope="col">Updated Date</th>
+          <th scope="col">AF</th>
+          <th scope="col">NYPL Item?</th>
+        </tr>
+      </thead>
+      <tbody class="result-table-body">
+        <% @refiles["data"].each do |refile| %>
+          <tr>
+            <td><%= refile["id"] %></td>
+            <td><strong><%= refile["itemBarcode"] %></strong></td>
+            <td><%= Date.parse(refile["createdDate"]).strftime("%Y-%m-%d") if refile["createdDate"] %></td>
+            <td><%= Date.parse(refile["updatedDate"]).strftime("%Y-%m-%d") if refile["updatedDate"]  %></td>
+            <td class="af-message"><%= refile["afMessage"].delete('["').delete('"]') if refile["afMessage"].present? %></td>
+            <td>yes<td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+
+    <nav class="nypl-results-pagination">
+      <%= refile_pagination(@refile_request, @refiles) %>
+    </nav>
+  <% else %>
+    <p><%= @refiles['statusCode'] %></p>
+  <% end %>
+</div>


### PR DESCRIPTION
Hey @emu47 

This adds pagination to the refile errors page. [(SCC-1128)](https://jira.nypl.org/browse/SCC-1128)
I've added a new gem in `development` & `test`, `pry-remote`.
I've also added instructions to the README about how to use it to get a breakpoint locally.
Soooo - you'll have to `docker-compose build --no-cache` once you checkout this branch.

The `RefileRequest` model is now an `ActiveModel`, mostly so we can use mass-assignment to tighten up [stuff like this](https://github.com/NYPL/scsbuster/compare/ss/paginate-refile-errors-page-SCC-1128?expand=1#diff-2eb2bf110a48bee6c79d3bbb377a549eL76).

Let me know what you thinkkkkk but - I'd like to have a timeboxed pair-programming session with you where we stop [returning the search results to another variable](https://github.com/NYPL/scsbuster/compare/ss/paginate-refile-errors-page-SCC-1128?expand=1#diff-2eb2bf110a48bee6c79d3bbb377a549eR19) and maybe have the `RefileRequest` object itself hold the search results in an Array.

Also - the more I wrote this, the more I think the code in `RefileRequest` feels like it belongs more in a class called `RefileErrorSearch`?

Anyway - what's in this branch works well enough - I just didn't want to blow everything apart in one fell swoop because I think you have a feature branch that's touching similar files and I didn't want to create a merge conflict nightmare.

