### PR TITLE
Refactor oauth

### DIFF
--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -10,7 +10,6 @@ class OauthController < ApplicationController
   # The redirect URL should now come with an authorization code.
   # 4. Get the acceess token with the authorization code by requesting to the access token URL of ISSO.
   # And redirect back to the redirect URI again.
-  # 5. Includes the access token we just got in the header for making HTTP requests.
   OAUTH_CLIENT = OAuth2::Client.new(ENV['CLIENT_ID'], ENV['CLIENT_SECRET'], site: ENV['OAUTH_SITE'])
   OAUTH_SCOPE  = 'openid login:staff offline_access'
 

--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -4,7 +4,7 @@ require 'securerandom'
 class OauthController < ApplicationController
   # OAuth2 authentication process:
   # 1. Construct the authorize URL to ISSO with required parameters, such as,
-  # client ID, client secret, redirect URI, state, and scope
+  # client ID, client secret, redirect URI, state, and scope.
   # 2. Redirect the user to the authorize URL for logging in
   # 3. After logged in, redirect the user back to our application.
   # The redirect URL should now come with an authorization code.
@@ -94,7 +94,7 @@ class OauthController < ApplicationController
       new_token = OAUTH_CLIENT.get_token(refresh_params)
       new_token.refresh_token = session[:refresh_token] unless new_token.refresh_token
 
-      # Clear old session
+      # Clear the old session
       reset_session
 
       session[:access_token] = new_token.token


### PR DESCRIPTION
This PR refactors the method of `refresh_access_token`.

The reason for doing this is that Joe and I noticed this method does not work occasionally. I am guessing it is because we rely on the class variable of OauthController to store the access token instance. However, while during all the redirections, sometimes the class variable got to be reset, so we lost the access token instance.

This PR builds the request of refreshing access token from session instead of using the one directly from OAuth2 gem, so we don't have to rely on the access token instance anymore. And thus, we can remove the class variable from OauthController.

I think this PR should be merged after the one, https://github.com/NYPL/scsbuster/pull/11
Just to reduce the complexity.