### PR TITLE
SS/JD add functional/feature/browser tests SCC-1213

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format doc

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development, :test do
   gem 'rspec'
   gem 'rspec-rails', '~> 3.7'
   gem 'rails-controller-testing'
+  gem 'capybara', '~> 3.8'
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     aws-eventstream (1.0.1)
     aws-partitions (1.97.0)
@@ -73,6 +75,13 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
+    capybara (3.8.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.1)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -135,6 +144,7 @@ GEM
     pry-remote (0.1.8)
       pry (~> 0.9)
       slop (~> 3.0)
+    public_suffix (3.0.3)
     rack (2.0.5)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -237,6 +247,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xpath (3.1.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -246,6 +258,7 @@ DEPENDENCIES
   aws-sdk-sqs (~> 1.3)
   bootsnap (>= 1.1.0)
   byebug
+  capybara (~> 3.8)
   coffee-rails (~> 4.2)
   design-toolkit!
   faraday

--- a/app/views/items/refile.html.erb
+++ b/app/views/items/refile.html.erb
@@ -69,11 +69,12 @@
       <p><%= date_select "refile_error_search", "date_end", use_month_numbers: true, with_css_classes: date_dropdown_classes('end'), start_year: 2010, end_year: Date.current.year, selected: @this_end_date, order: [:month, :day, :year], aria: { labelledby: 'endDate-label endDate-status' } %></p>
       <span class="nypl-field-status" id="endDate-status" aria-live="assertive" aria-atomic="true">The end date as the format as MM/DD/YYYY</span>
     </div>
-    <div class="nypl-submit-button-wrapper"><%= submit_tag 'Submit', class: "nypl-primary-button" %></div>
+    <div class="nypl-submit-button-wrapper"><%= submit_tag 'Submit', class: "nypl-primary-button", id: 'refileSearchSubmitButton' %></div>
   </div>
 <% end -%>
 
 <div>
+
   <% if @refiles["data"].present? %>
     <p class='display-result-text'>Displaying <%= cardinality_of_current_results(@refile_error_search, @refiles) %> of <%= @refiles["totalCount"] %> errors from <%= @refile_error_search.date_start %> to <%= @refile_error_search.date_end %></p>
 

--- a/app/views/items/refile.html.erb
+++ b/app/views/items/refile.html.erb
@@ -34,7 +34,7 @@
         <%= text_field_tag :barcode, @barcode, { class: 'required', aria: { labelledby: 'send-refile-barcode barcode-status' } } %>
         <span class="nypl-field-status" id="barcodes-status" aria-live="assertive" aria-atomic="true">Enter a single barcode. Make sure the item is available in SCSB first.</span>
       </div>
-      <div class="nypl-submit-button-wrapper"><%= submit_tag 'Submit', class: "nypl-primary-button" %></div>
+      <div class="nypl-submit-button-wrapper"><%= submit_tag 'Submit', class: "nypl-primary-button", id: "refileRequestSubmitButton" %></div>
     </p>
   </div>
 <% end -%>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,6 +18,9 @@ Rails.application.configure do
     'Cache-Control' => "public, max-age=#{1.hour.to_i}"
   }
 
+  # Don't pollute test output in the console
+  config.logger = NyplLogFormatter.new(File.join(Rails.root, 'log', 'test.log'))
+
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/spec/features/check_scsbuster_update_metadata_success_spec.rb
+++ b/spec/features/check_scsbuster_update_metadata_success_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'update metadata single barcode success' do
+  describe 'When on the Update SCSB Metadata page' do
+
+    describe 'When valid barcode number is  entered' do
+      before(:each) do
+        cut_off_sqs!
+        skip_authentication_to(update_metadata_path)
+        @good_barcode = '1' * 14
+      end
+
+      it 'a single valid barcode should display a success message' do
+        aggregate_failures 'check-success' do
+          fill_in('barcodes', with: @good_barcode)
+          click_submit_value('submit')
+          within('.nypl-form-success') do
+            expect(find(:xpath, "//div[@class='nypl-form-success']/h2").text.downcase).to include('success')
+            expect(find(:xpath, "//div[@class='nypl-form-success']/p").text.downcase).to include('the barcode(s) have been submitted for processing')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/refile_errors_spec.rb
+++ b/spec/features/refile_errors_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe 'SCSBuster Refile errors' do
+  describe 'When on the Refile page' do
+    before(:each) do
+      # So the controller doesn't try to fetch paginated refile errors from LSP
+      allow_any_instance_of(RefileErrorSearch).to receive(:get_refiles) { {} }
+      skip_authentication_to(refile_path)
+    end
+
+    describe 'Given an incorrect barcode is entered' do
+      describe 'When barcode is too long' do
+        before(:each) do
+          @this_error_barcode = 'x' * 21
+        end
+
+        it ' - 21 character barcode should display error msg: must be up to 20 alphanumeric characters in length' do
+          aggregate_failures 'check-num' do
+            fill_in('barcode', with: @this_error_barcode)
+            click_button('refileRequestSubmitButton')
+            within('#flash_error') do
+              expect(find(:xpath, "//div[@id='flash_error']/p").text.downcase).to include('the barcode must be up to 20 alphanumeric characters in length')
+            end
+          end
+        end
+
+        it ' - and too long barcode should remain on form' do
+          fill_in('barcode', with: @this_error_barcode)
+          click_button('refileRequestSubmitButton')
+          expect(all(:xpath, "//div[@class='nypl-text-field-with-label']/input[@id='barcode' and @value='#{@this_error_barcode}']").size).to eq(1)
+        end
+      end
+
+      describe 'When barcode is empty' do
+        before(:each) do
+          fill_in('barcode', with: '')
+          click_button('refileRequestSubmitButton')
+        end
+
+        it ' - should display error msg: must be up to 20 alphanumeric characters in length' do
+          aggregate_failures 'check-empty' do
+            within('#flash_error') do
+              expect(find(:xpath, "//div[@id='flash_error']/p").text.downcase).to include('the barcode must be up to 20 alphanumeric characters in length')
+            end
+          end
+        end
+
+        it ' - and should display error msg: please enter a barcode' do
+          expect(find(:xpath, "//div[@id='flash_error']/p").text.downcase).to include('please enter a barcode')
+        end
+      end
+    end
+  end
+end

--- a/spec/features/refile_errors_spec.rb
+++ b/spec/features/refile_errors_spec.rb
@@ -11,7 +11,7 @@ describe 'SCSBuster Refile errors' do
     describe 'Given an incorrect barcode is entered' do
       describe 'When barcode is too long' do
         before(:each) do
-          @this_error_barcode = 'x' * 21
+          @this_error_barcode = '1' * 21
         end
 
         it ' - 21 character barcode should display error msg: must be up to 20 alphanumeric characters in length' do

--- a/spec/features/refile_search_spec.rb
+++ b/spec/features/refile_search_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+describe 'SCSBuster Refile query' do
+  describe 'When on the Refile page' do
+    describe 'Given a valid date range that returns over 50 results' do
+      it 'should see some refile error results displayed' do
+        aggregate_failures 'check-good-date' do
+          stub_refile_error_search_with(page: 1)
+          skip_authentication_to(refile_path)
+
+          @this_display_count = find(:xpath, "//p[@class='display-result-text']").text
+          @current_month = Time.now.strftime('%m')
+          @start_month = @current_month.to_i - 1
+          expect(find(:xpath, "//p[@class='display-result-text']").text.downcase).to include('displaying 1-25 of ')
+
+          @current_display_count = find(:xpath, "//p[@class='display-result-text']").text
+
+          @display_count = @this_display_count.downcase.gsub(/displaying 1-25 of (\d+) errors from .*\z/, '\1').to_i
+          @display_last_page = (@display_count / 25) + 1
+          expect(@display_count.to_i).to be > 50
+        end
+      end
+
+      it 'should only see a next-link box on first page' do
+        aggregate_failures 'check-next-link' do
+          stub_refile_error_search_with(page: 1)
+          skip_authentication_to(refile_path)
+
+          @next_link_count = all(:xpath, "//nav[@class='nypl-results-pagination']/a[@class='next-link pointer']").size
+          expect(@next_link_count).to eq(1)
+
+          @prev_link_count = all(:xpath, "//nav[@class='nypl-results-pagination']/a[@class='previous-link pointer']").size
+          expect(@prev_link_count).to eq(0)
+        end
+      end
+
+      it 'should see previous-link and next-link boxes on second page' do
+        aggregate_failures 'check-other-links' do
+          stub_refile_error_search_with(page: 2)
+          skip_authentication_to(refile_path(page: 2))
+
+          @next_link_count = all(:xpath, "//nav[@class='nypl-results-pagination']/a[@class='next-link pointer']").size
+          expect(@next_link_count).to eq(1)
+
+          @prev_link_count = all(:xpath, "//nav[@class='nypl-results-pagination']/a[@class='previous-link pointer']").size
+          expect(@prev_link_count).to eq(1)
+        end
+      end
+
+      describe 'When on the last page' do
+        before(:each) do
+          stub_refile_error_search_with(page: 4, total: 100)
+          skip_authentication_to(refile_path(page: 4))
+        end
+
+        it 'should only see a previous-link box' do
+          aggregate_failures 'check-last-links' do
+            @next_link_count = all(:xpath, "//nav[@class='nypl-results-pagination']/a[@class='next-link pointer']").size
+            expect(@next_link_count).to eq(0)
+
+            @prev_link_count = all(:xpath, "//nav[@class='nypl-results-pagination']/a[@class='previous-link pointer']").size
+            expect(@prev_link_count).to eq(1)
+
+            # last page should be the same as reported by results-total and page n of n display
+            expect(last_page?).to be true
+          end
+        end
+
+        it 'and clicking previous-link box should go to previous page' do
+          find(:xpath, "//nav[@class='nypl-results-pagination']/a[@class='previous-link pointer']").click
+
+          # look for correct next and previous links
+          @next_link_count = all(:xpath, "//nav[@class='nypl-results-pagination']/a[@class='next-link pointer']").size
+          expect(@next_link_count).to eq(1)
+
+          @prev_link_count = all(:xpath, "//nav[@class='nypl-results-pagination']/a[@class='previous-link pointer']").size
+          expect(@prev_link_count).to eq(1)
+
+          this_page_display = find(:xpath, "//nav[@class='nypl-results-pagination']/span[@class='page-count']").text.downcase
+          @get_current_page = this_page_display.gsub(/page (\d+) of (\d+)/, '\1')
+          @get_last_page = this_page_display.gsub(/page (\d+) of (\d+)/, '\2')
+
+          expect(@get_current_page.to_i).to eq((@get_last_page.to_i - 1))
+        end
+      end
+    end
+  end
+end

--- a/spec/features/refile_success_spec.rb
+++ b/spec/features/refile_success_spec.rb
@@ -7,7 +7,7 @@ describe 'SCSBuster Refile success' do
         allow_any_instance_of(RefileErrorSearch).to receive(:get_refiles) { {} }
         # Don't actually hit the refile request endpoint
         allow_any_instance_of(RefileRequest).to receive(:post_refile) { {} }
-        skip_authentication_to(refile_path) { nil }
+        skip_authentication_to(refile_path)
         @good_barcode = 'b11556466x'
       end
 

--- a/spec/features/refile_success_spec.rb
+++ b/spec/features/refile_success_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe 'SCSBuster Refile success' do
+  describe 'When on the Refile page' do
+    describe 'When a correct barcode number is entered' do
+      before(:each) do
+        allow_any_instance_of(RefileErrorSearch).to receive(:get_refiles) { {} }
+        # Don't actually hit the refile request endpoint
+        allow_any_instance_of(RefileRequest).to receive(:post_refile) { {} }
+        skip_authentication_to(refile_path) { nil }
+        @good_barcode = 'b11556466x'
+      end
+
+      it ' - normal 20-digit barcode should display success message' do
+        aggregate_failures 'check-success' do
+          find(:xpath, "//input[@id='barcode']").set(@good_barcode)
+          find(:xpath, "//form[@action='/send_refile_request']/div/div[@class='nypl-submit-button-wrapper']/input[@type='submit']").click
+
+          within('.nypl-form-success') do
+            expect(find(:xpath, "//div[@class='nypl-form-success']/h2").text.downcase).to include('success')
+            expect(find(:xpath, "//div[@class='nypl-form-success']/p").text.downcase).to include('the barcode has been submitted for processing')
+          end
+        end
+      end
+
+      it ' - non-numeric barcode b12345x should display success message' do
+        aggregate_failures 'check-nonnum' do
+          fill_in('barcode', with: 'b12345x')
+          find(:xpath, "//form[@action='/send_refile_request']/div/div[@class='nypl-submit-button-wrapper']/input[@type='submit']").click
+
+          within('.nypl-form-success') do
+            expect(find(:xpath, "//div[@class='nypl-form-success']/h2").text.downcase).to include('success')
+            expect(find(:xpath, "//div[@class='nypl-form-success']/p").text.downcase).to include('the barcode has been submitted for processing')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/transfer_barcode_errors_spec.rb
+++ b/spec/features/transfer_barcode_errors_spec.rb
@@ -1,136 +1,89 @@
 require 'rails_helper'
 
-describe "SCSBuster transfer barcode errors" do
+describe 'SCSBuster transfer barcode errors' do
+  describe 'When on the Transfer Barcode & Update Metadata page' do
 
-  describe "When on the Transfer Barcode & Update Metadata page" do
-  
     before(:each) do
       skip_authentication_to(transfer_metadata_path)
       cut_off_sqs!
     end
 
-    describe "Given a correct bnumber and an invalid barcode is entered" do 
+    describe 'Given a correct bnumber and an invalid barcode is entered' do 
+      describe 'non-numerical barcodes' do
 
-        describe "non-numerical barcodes" do
-          
-          before(:each) do
-            @this_error_barcode = 'x' * 14
-            @this_error_bnumber = "b11556466x"
-          end
-          
-          it "should fail non-numerical barcode with error msg" do
-
-            aggregate_failures "check-num" do
-
-              find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
-
-              find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
-
-              click_submit_value("submit")
-
-              within('#flash_error') do
-                expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
-              end
-            
-            #/aggregate_failures
-            end
-          
-          #/it-block
-          end
+        before(:each) do
+          @this_error_barcode = 'x' * 14
+          @this_error_bnumber = 'b11556466x'
+        end
         
+        it 'should fail non-numerical barcode with error msg' do
+          aggregate_failures 'check-num' do
+            find(:xpath, "//input[@id='barcode']").set('#{@this_error_barcode}')
+            find(:xpath, "//input[@id='bib_record_number']").set('#{@this_error_bnumber}')
+            click_submit_value('submit')
+            within('#flash_error') do
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('must be 14 numerical digits in length')
+            end
+          end
+        end
+      end
+
+      describe 'too long barcodes' do
+
+        before(:each) do
+          @this_error_barcode = '1' * 15
+          @this_error_bnumber = 'b11556466x'
         end
 
-        describe  "too long barcodes" do
-
-          before(:each) do
-            @this_error_barcode = '1' * 15
-            @this_error_bnumber = "b11556466x"
-          end
-
-          it "should fail too-long barcode with error msg" do
-
-            aggregate_failures "check-long" do
-
-              find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
-
-              find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
-
-              click_submit_value("submit")
-
-              within('#flash_error') do
-                expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
-              end
-          
-            #/aggregate_failures
+        it 'should fail too-long barcode with error msg' do
+          aggregate_failures 'check-long' do
+            find(:xpath, "//input[@id='barcode']").set('#{@this_error_barcode}')
+            find(:xpath, "//input[@id='bib_record_number']").set('#{@this_error_bnumber}')
+            click_submit_value('submit')
+            within('#flash_error') do
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('must be 14 numerical digits in length')
             end
-        
-          #/it-block
           end
-        
+        end
+      end
+
+      describe 'short barcodes' do
+
+        before(:each) do
+          @this_error_barcode = '1' * 13
+          @this_error_bnumber = 'b11556466x'
         end
 
-        describe  "short barcodes" do
-
-          before(:each) do
-            @this_error_barcode = '1' * 13
-            @this_error_bnumber = "b11556466x"
-          end
-
-          it "should fail short barcode with error msg" do
-
-            aggregate_failures "check-short" do
-
-              find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
-
-              find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
-
-              click_submit_value("submit")
-
-              within('#flash_error') do
-                expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
-              end
-          
-            #/aggregate_failures
+        it 'should fail short barcode with error msg' do
+          aggregate_failures 'check-short' do
+            find(:xpath, "//input[@id='barcode']").set('#{@this_error_barcode}')
+            find(:xpath, "//input[@id='bib_record_number']").set('#{@this_error_bnumber}')
+            click_submit_value('submit')
+            within('#flash_error') do
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('must be 14 numerical digits in length')
             end
-        
-          #/it-block
           end
-        
+        end
+      end
+
+      describe 'empty barcodes' do
+
+        before(:each) do
+          @this_error_barcode = ''
+          @this_error_bnumber = 'b11556466x'
         end
 
-        describe  "empty barcodes" do
-
-          before(:each) do
-            @this_error_barcode = ''
-            @this_error_bnumber = "b11556466x"
-          end
-
-          it "should fail empty barcode with error msg" do
-
-            aggregate_failures "check-short" do
-
-              find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
-
-              find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
-
-              click_submit_value("submit")
-
-              within('#flash_error') do
-                expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
-              end
-          
-            #/aggregate_failures
+        it 'should fail empty barcode with error msg' do
+          aggregate_failures 'check-short' do
+            find(:xpath, "//input[@id='barcode']").set('#{@this_error_barcode}')
+            find(:xpath, "//input[@id='bib_record_number']").set('#{@this_error_bnumber}')
+            click_submit_value('submit')
+            within('#flash_error') do
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('must be 14 numerical digits in length')
             end
-        
-          #/it-block
           end
-        
         end
-
-    #/inner-inner-describe-given-an-incorrect-barcode
+      end
     end
-
-  #/inner-describe
   end
-  
 end

--- a/spec/features/transfer_barcode_errors_spec.rb
+++ b/spec/features/transfer_barcode_errors_spec.rb
@@ -2,135 +2,135 @@ require 'rails_helper'
 
 describe "SCSBuster transfer barcode errors" do
 
-	describe "When on the Transfer Barcode & Update Metadata page" do
-	
-		before(:each) do
-			skip_authentication_to(transfer_metadata_path)
-			cut_off_sqs!
-		end
+  describe "When on the Transfer Barcode & Update Metadata page" do
+  
+    before(:each) do
+      skip_authentication_to(transfer_metadata_path)
+      cut_off_sqs!
+    end
 
-		describe "Given a correct bnumber and an invalid barcode is entered" do 
+    describe "Given a correct bnumber and an invalid barcode is entered" do 
 
-				describe "non-numerical barcodes" do
-					
-					before(:each) do
-						@this_error_barcode = 'x' * 14
-						@this_error_bnumber = "b11556466x"
-					end
-					
-					it "should fail non-numerical barcode with error msg" do
+        describe "non-numerical barcodes" do
+          
+          before(:each) do
+            @this_error_barcode = 'x' * 14
+            @this_error_bnumber = "b11556466x"
+          end
+          
+          it "should fail non-numerical barcode with error msg" do
 
-						aggregate_failures "check-num" do
+            aggregate_failures "check-num" do
 
-							find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+              find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
 
-							find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+              find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
 
-							click_submit_value("submit")
+              click_submit_value("submit")
 
-							within('#flash_error') do
-								expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
-							end
-						
-						#/aggregate_failures
-						end
-					
-					#/it-block
-					end
-				
-				end
+              within('#flash_error') do
+                expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+              end
+            
+            #/aggregate_failures
+            end
+          
+          #/it-block
+          end
+        
+        end
 
-				describe	"too long barcodes" do
+        describe  "too long barcodes" do
 
-					before(:each) do
-						@this_error_barcode = '1' * 15
-						@this_error_bnumber = "b11556466x"
-					end
+          before(:each) do
+            @this_error_barcode = '1' * 15
+            @this_error_bnumber = "b11556466x"
+          end
 
-					it "should fail too-long barcode with error msg" do
+          it "should fail too-long barcode with error msg" do
 
-						aggregate_failures "check-long" do
+            aggregate_failures "check-long" do
 
-							find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+              find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
 
-							find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+              find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
 
-							click_submit_value("submit")
+              click_submit_value("submit")
 
-							within('#flash_error') do
-								expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
-							end
-					
-						#/aggregate_failures
-						end
-				
-					#/it-block
-					end
-				
-				end
+              within('#flash_error') do
+                expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+              end
+          
+            #/aggregate_failures
+            end
+        
+          #/it-block
+          end
+        
+        end
 
-				describe	"short barcodes" do
+        describe  "short barcodes" do
 
-					before(:each) do
-						@this_error_barcode = '1' * 13
-						@this_error_bnumber = "b11556466x"
-					end
+          before(:each) do
+            @this_error_barcode = '1' * 13
+            @this_error_bnumber = "b11556466x"
+          end
 
-					it "should fail short barcode with error msg" do
+          it "should fail short barcode with error msg" do
 
-						aggregate_failures "check-short" do
+            aggregate_failures "check-short" do
 
-							find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+              find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
 
-							find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+              find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
 
-							click_submit_value("submit")
+              click_submit_value("submit")
 
-							within('#flash_error') do
-								expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
-							end
-					
-						#/aggregate_failures
-						end
-				
-					#/it-block
-					end
-				
-				end
+              within('#flash_error') do
+                expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+              end
+          
+            #/aggregate_failures
+            end
+        
+          #/it-block
+          end
+        
+        end
 
-				describe	"empty barcodes" do
+        describe  "empty barcodes" do
 
-					before(:each) do
-						@this_error_barcode = ''
-						@this_error_bnumber = "b11556466x"
-					end
+          before(:each) do
+            @this_error_barcode = ''
+            @this_error_bnumber = "b11556466x"
+          end
 
-					it "should fail empty barcode with error msg" do
+          it "should fail empty barcode with error msg" do
 
-						aggregate_failures "check-short" do
+            aggregate_failures "check-short" do
 
-							find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+              find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
 
-							find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+              find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
 
-							click_submit_value("submit")
+              click_submit_value("submit")
 
-							within('#flash_error') do
-								expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
-							end
-					
-						#/aggregate_failures
-						end
-				
-					#/it-block
-					end
-				
-				end
+              within('#flash_error') do
+                expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+              end
+          
+            #/aggregate_failures
+            end
+        
+          #/it-block
+          end
+        
+        end
 
-		#/inner-inner-describe-given-an-incorrect-barcode
-		end
+    #/inner-inner-describe-given-an-incorrect-barcode
+    end
 
-	#/inner-describe
-	end
-	
+  #/inner-describe
+  end
+  
 end

--- a/spec/features/transfer_barcode_errors_spec.rb
+++ b/spec/features/transfer_barcode_errors_spec.rb
@@ -1,85 +1,85 @@
 require 'rails_helper'
 
-describe 'SCSBuster transfer barcode errors' do
-  describe 'When on the Transfer Barcode & Update Metadata page' do
-
+describe "SCSBuster transfer barcode errors" do
+  describe "When on the Transfer Barcode & Update Metadata page" do
+  
     before(:each) do
       skip_authentication_to(transfer_metadata_path)
       cut_off_sqs!
     end
 
-    describe 'Given a correct bnumber and an invalid barcode is entered' do 
-      describe 'non-numerical barcodes' do
-
+    describe "Given a correct bnumber and an invalid barcode is entered" do 
+      describe "non-numerical barcodes" do
+        
         before(:each) do
           @this_error_barcode = 'x' * 14
-          @this_error_bnumber = 'b11556466x'
+          @this_error_bnumber = "b11556466x"
         end
         
-        it 'should fail non-numerical barcode with error msg' do
-          aggregate_failures 'check-num' do
-            find(:xpath, "//input[@id='barcode']").set('#{@this_error_barcode}')
-            find(:xpath, "//input[@id='bib_record_number']").set('#{@this_error_bnumber}')
-            click_submit_value('submit')
+        it "should fail non-numerical barcode with error msg" do
+          aggregate_failures "check-num" do
+            find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+            find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+            click_submit_value("submit")
             within('#flash_error') do
-              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('must be 14 numerical digits in length')
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
             end
           end
         end
       end
 
-      describe 'too long barcodes' do
+      describe  "too long barcodes" do
 
         before(:each) do
           @this_error_barcode = '1' * 15
-          @this_error_bnumber = 'b11556466x'
+          @this_error_bnumber = "b11556466x"
         end
 
-        it 'should fail too-long barcode with error msg' do
-          aggregate_failures 'check-long' do
-            find(:xpath, "//input[@id='barcode']").set('#{@this_error_barcode}')
-            find(:xpath, "//input[@id='bib_record_number']").set('#{@this_error_bnumber}')
-            click_submit_value('submit')
+        it "should fail too-long barcode with error msg" do
+          aggregate_failures "check-long" do
+            find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+            find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+            click_submit_value("submit")
             within('#flash_error') do
-              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('must be 14 numerical digits in length')
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
             end
           end
         end
       end
 
-      describe 'short barcodes' do
+      describe  "short barcodes" do
 
         before(:each) do
           @this_error_barcode = '1' * 13
-          @this_error_bnumber = 'b11556466x'
+          @this_error_bnumber = "b11556466x"
         end
 
-        it 'should fail short barcode with error msg' do
-          aggregate_failures 'check-short' do
-            find(:xpath, "//input[@id='barcode']").set('#{@this_error_barcode}')
-            find(:xpath, "//input[@id='bib_record_number']").set('#{@this_error_bnumber}')
-            click_submit_value('submit')
+        it "should fail short barcode with error msg" do
+          aggregate_failures "check-short" do
+            find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+            find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+            click_submit_value("submit")
             within('#flash_error') do
-              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('must be 14 numerical digits in length')
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
             end
           end
         end
       end
 
-      describe 'empty barcodes' do
+      describe  "empty barcodes" do
 
         before(:each) do
           @this_error_barcode = ''
-          @this_error_bnumber = 'b11556466x'
+          @this_error_bnumber = "b11556466x"
         end
 
-        it 'should fail empty barcode with error msg' do
-          aggregate_failures 'check-short' do
-            find(:xpath, "//input[@id='barcode']").set('#{@this_error_barcode}')
-            find(:xpath, "//input[@id='bib_record_number']").set('#{@this_error_bnumber}')
-            click_submit_value('submit')
+        it "should fail empty barcode with error msg" do
+          aggregate_failures "check-short" do
+            find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+            find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+            click_submit_value("submit")
             within('#flash_error') do
-              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('must be 14 numerical digits in length')
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
             end
           end
         end

--- a/spec/features/transfer_barcode_errors_spec.rb
+++ b/spec/features/transfer_barcode_errors_spec.rb
@@ -5,80 +5,20 @@ describe "SCSBuster transfer barcode errors" do
 	describe "When on the Transfer Barcode & Update Metadata page" do
 	
 		before(:each) do
-      skip_authentication_to(transfer_metadata_path)
+			skip_authentication_to(transfer_metadata_path)
+			cut_off_sqs!
 		end
 
-		describe "Given an incorrect barcode is entered" do 
-		
-			#describe "It should fail for these conditions:" do
-			
-				# 				before(:all) do
-				# 
-				# 					if (defined?(ENV['ERROR_BARCODE']) && ENV['ERROR_BARCODE'] != nil) then
-				# 						@this_error_barcode = ENV['ERROR_BARCODE']
-				# 					else
-				# 						#insert "good" slug here.
-				# 						@this_error_barcode = "33433047299254"
-				# 					end
-				# 
-				# 					if (defined?(ENV['ERROR_BNUMBER']) && ENV['ERROR_BNUMBER'] != nil) then
-				# 						@this_error_bnumber = ENV['ERROR_BNUMBER']
-				# 					else
-				# 						#insert "good" slug here.
-				# 						@this_error_bnumber = "b11556466x"
-				# 					end
-				# 
-				# 				
-				# 				end
+		describe "Given a correct bnumber and an invalid barcode is entered" do 
 
-				# this first block is for inline-testing of barcode errors, normally will be commented out
-
-				# 				if (defined?(ENV['ERROR_BARCODE']) && ENV['ERROR_BARCODE'] != nil) 
-				# 
-				# 					it " - generic error for #{ENV['ERROR_BARCODE']} displays:  (WIP)" do
-				# 
-				# 						aggregate_failures "check-generic" do
-				# 
-				# 							#puts "this_error_barcode: #{@this_error_barcode}/#{ENV['ERROR_BARCODE']}"
-				# 							#puts "this_error_bnumber: #{@this_error_bnumber}/#{ENV['ERROR_BNUMBER']}"
-				# 	
-				# 							save_snap("pre_generic","png")
-				# 							#save_snap("pre_generic","html")
-				# 				
-				# 							find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
-				# 
-				# 							find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
-				# 
-				# 							click_submit_value("submit")
-				# 
-				# 							sleep 2
-				# 							save_snap("post_generic","png")
-				# 							#save_snap("post_generic","html")
-				# 
-				# 							within('#flash_error') do
-				# 					
-				# 								expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
-				# 
-				# 				
-				# 								#expect(fail-message).to eq("fail-message")
-				# 					
-				# 							end
-				# 					
-				# 						end
-				# 				
-				# 					end
-				# 					
-				# 				#/if-filter
-				# 				end
-
-				describe "When a non-numerical barcode is entered" do
+				describe "non-numerical barcodes" do
 					
 					before(:each) do
 						@this_error_barcode = 'x' * 14
 						@this_error_bnumber = "b11556466x"
 					end
 					
-					it "it should fail with error msg: must be 14 numerical digits in length" do
+					it "should fail non-numerical barcode with error msg" do
 
 						aggregate_failures "check-num" do
 
@@ -100,14 +40,14 @@ describe "SCSBuster transfer barcode errors" do
 				
 				end
 
-				describe	"When a too long barcode is entered" do
+				describe	"too long barcodes" do
 
 					before(:each) do
 						@this_error_barcode = '1' * 15
 						@this_error_bnumber = "b11556466x"
 					end
 
-					it "it should fail with error msg: must be 14 numerical digits in length" do
+					it "should fail too-long barcode with error msg" do
 
 						aggregate_failures "check-long" do
 
@@ -129,14 +69,14 @@ describe "SCSBuster transfer barcode errors" do
 				
 				end
 
-				describe	"When a too short barcode is entered" do
+				describe	"short barcodes" do
 
 					before(:each) do
 						@this_error_barcode = '1' * 13
 						@this_error_bnumber = "b11556466x"
 					end
 
-					it "it should fail with error msg: must be 14 numerical digits in length" do
+					it "should fail short barcode with error msg" do
 
 						aggregate_failures "check-short" do
 
@@ -158,83 +98,39 @@ describe "SCSBuster transfer barcode errors" do
 				
 				end
 
+				describe	"empty barcodes" do
 
+					before(:each) do
+						@this_error_barcode = ''
+						@this_error_bnumber = "b11556466x"
+					end
 
-# temp block
-# 				it " - too long barcode 12345678123456781234567 (error msg: must be 14 numerical digits in length)" do
-# 
-# 
-# 					aggregate_failures "check-long" do
-# 
-# 						save_snap("pre_long","png")
-# 						#save_snap("pre_long","html")
-# 				
-# 						find(:xpath, "//input[@id='barcode']").set("123456781234567812345678")
-# 						find(:xpath, "//input[@id='bib_record_number']").set("b11556466x")
-# 
-# 						click_submit_value("submit")
-# 
-# 						sleep 2
-# 						save_snap("post_long","png")
-# 						#save_snap("post_long","html")
-# 
-# 						within('#flash_error') do
-# 					
-# 							expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
-# 
-# 				
-# 							#expect(fail-message).to eq("fail-message")
-# 					
-# 						end
-# 					
-# 					end
-# 				
-# 				#/it-block
-# 				end
-# 
-# 				it " - empty barcode (error msg: must be 14 numerical digits in length)" do
-# 
-# 					aggregate_failures "check-empty" do
-# 
-# 						save_snap("pre_empty","png")
-# 						#save_snap("pre_empty","html")
-# 				
-# 						find(:xpath, "//input[@id='barcode']").set("")
-# 						find(:xpath, "//input[@id='bib_record_number']").set("b11556466x")
-# 
-# 						click_submit_value("submit")
-# 
-# 						sleep 2
-# 						save_snap("post_empty","png")
-# 						#save_snap("post_empty","html")
-# 
-# 						within('#flash_error') do
-# 					
-# 							expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
-# 
-# 				
-# 							#expect(fail-message).to eq("fail-message")
-# 					
-# 						end
-# 					
-# 					end
+					it "should fail empty barcode with error msg" do
+
+						aggregate_failures "check-short" do
+
+							find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+
+							find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+
+							click_submit_value("submit")
+
+							within('#flash_error') do
+								expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+							end
+					
+						#/aggregate_failures
+						end
 				
-
-				# 			<div class="nypl-text-field-with-label">
-				#         <label class="required">Barcode</label><span class="nypl-required-field"> Required</span>
-				#         <input type="text" name="barcode" id="barcode" value="" class="required">
-				#         <span class="nypl-field-status" id="barcodes-status" aria-live="assertive" aria-atomic="true">Enter a single barcode.</span>
-				#       </div>
-			
-				#       				#expect(fail-message).to eq("fail-message")
+					#/it-block
+					end
 				
-			
-			#/inner-inner-inner-describe-it-should-fail-for-these-conditions
-			#end
-		
-		#/inner-inner-describe-
+				end
+
+		#/inner-inner-describe-given-an-incorrect-barcode
 		end
 
+	#/inner-describe
 	end
 	
 end

--- a/spec/features/transfer_barcode_errors_spec.rb
+++ b/spec/features/transfer_barcode_errors_spec.rb
@@ -1,0 +1,240 @@
+require 'rails_helper'
+
+describe "SCSBuster transfer barcode errors" do
+
+	describe "When on the Transfer Barcode & Update Metadata page" do
+	
+		before(:each) do
+      skip_authentication_to(transfer_metadata_path)
+		end
+
+		describe "Given an incorrect barcode is entered" do 
+		
+			#describe "It should fail for these conditions:" do
+			
+				# 				before(:all) do
+				# 
+				# 					if (defined?(ENV['ERROR_BARCODE']) && ENV['ERROR_BARCODE'] != nil) then
+				# 						@this_error_barcode = ENV['ERROR_BARCODE']
+				# 					else
+				# 						#insert "good" slug here.
+				# 						@this_error_barcode = "33433047299254"
+				# 					end
+				# 
+				# 					if (defined?(ENV['ERROR_BNUMBER']) && ENV['ERROR_BNUMBER'] != nil) then
+				# 						@this_error_bnumber = ENV['ERROR_BNUMBER']
+				# 					else
+				# 						#insert "good" slug here.
+				# 						@this_error_bnumber = "b11556466x"
+				# 					end
+				# 
+				# 				
+				# 				end
+
+				# this first block is for inline-testing of barcode errors, normally will be commented out
+
+				# 				if (defined?(ENV['ERROR_BARCODE']) && ENV['ERROR_BARCODE'] != nil) 
+				# 
+				# 					it " - generic error for #{ENV['ERROR_BARCODE']} displays:  (WIP)" do
+				# 
+				# 						aggregate_failures "check-generic" do
+				# 
+				# 							#puts "this_error_barcode: #{@this_error_barcode}/#{ENV['ERROR_BARCODE']}"
+				# 							#puts "this_error_bnumber: #{@this_error_bnumber}/#{ENV['ERROR_BNUMBER']}"
+				# 	
+				# 							save_snap("pre_generic","png")
+				# 							#save_snap("pre_generic","html")
+				# 				
+				# 							find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+				# 
+				# 							find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+				# 
+				# 							click_submit_value("submit")
+				# 
+				# 							sleep 2
+				# 							save_snap("post_generic","png")
+				# 							#save_snap("post_generic","html")
+				# 
+				# 							within('#flash_error') do
+				# 					
+				# 								expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+				# 
+				# 				
+				# 								#expect(fail-message).to eq("fail-message")
+				# 					
+				# 							end
+				# 					
+				# 						end
+				# 				
+				# 					end
+				# 					
+				# 				#/if-filter
+				# 				end
+
+				describe "When a non-numerical barcode is entered" do
+					
+					before(:each) do
+						@this_error_barcode = 'x' * 14
+						@this_error_bnumber = "b11556466x"
+					end
+					
+					it "it should fail with error msg: must be 14 numerical digits in length" do
+
+						aggregate_failures "check-num" do
+
+							find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+
+							find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+
+							click_submit_value("submit")
+
+							within('#flash_error') do
+								expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+							end
+						
+						#/aggregate_failures
+						end
+					
+					#/it-block
+					end
+				
+				end
+
+				describe	"When a too long barcode is entered" do
+
+					before(:each) do
+						@this_error_barcode = '1' * 15
+						@this_error_bnumber = "b11556466x"
+					end
+
+					it "it should fail with error msg: must be 14 numerical digits in length" do
+
+						aggregate_failures "check-long" do
+
+							find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+
+							find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+
+							click_submit_value("submit")
+
+							within('#flash_error') do
+								expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+							end
+					
+						#/aggregate_failures
+						end
+				
+					#/it-block
+					end
+				
+				end
+
+				describe	"When a too short barcode is entered" do
+
+					before(:each) do
+						@this_error_barcode = '1' * 13
+						@this_error_bnumber = "b11556466x"
+					end
+
+					it "it should fail with error msg: must be 14 numerical digits in length" do
+
+						aggregate_failures "check-short" do
+
+							find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+
+							find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+
+							click_submit_value("submit")
+
+							within('#flash_error') do
+								expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+							end
+					
+						#/aggregate_failures
+						end
+				
+					#/it-block
+					end
+				
+				end
+
+
+
+# temp block
+# 				it " - too long barcode 12345678123456781234567 (error msg: must be 14 numerical digits in length)" do
+# 
+# 
+# 					aggregate_failures "check-long" do
+# 
+# 						save_snap("pre_long","png")
+# 						#save_snap("pre_long","html")
+# 				
+# 						find(:xpath, "//input[@id='barcode']").set("123456781234567812345678")
+# 						find(:xpath, "//input[@id='bib_record_number']").set("b11556466x")
+# 
+# 						click_submit_value("submit")
+# 
+# 						sleep 2
+# 						save_snap("post_long","png")
+# 						#save_snap("post_long","html")
+# 
+# 						within('#flash_error') do
+# 					
+# 							expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+# 
+# 				
+# 							#expect(fail-message).to eq("fail-message")
+# 					
+# 						end
+# 					
+# 					end
+# 				
+# 				#/it-block
+# 				end
+# 
+# 				it " - empty barcode (error msg: must be 14 numerical digits in length)" do
+# 
+# 					aggregate_failures "check-empty" do
+# 
+# 						save_snap("pre_empty","png")
+# 						#save_snap("pre_empty","html")
+# 				
+# 						find(:xpath, "//input[@id='barcode']").set("")
+# 						find(:xpath, "//input[@id='bib_record_number']").set("b11556466x")
+# 
+# 						click_submit_value("submit")
+# 
+# 						sleep 2
+# 						save_snap("post_empty","png")
+# 						#save_snap("post_empty","html")
+# 
+# 						within('#flash_error') do
+# 					
+# 							expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+# 
+# 				
+# 							#expect(fail-message).to eq("fail-message")
+# 					
+# 						end
+# 					
+# 					end
+				
+
+				# 			<div class="nypl-text-field-with-label">
+				#         <label class="required">Barcode</label><span class="nypl-required-field"> Required</span>
+				#         <input type="text" name="barcode" id="barcode" value="" class="required">
+				#         <span class="nypl-field-status" id="barcodes-status" aria-live="assertive" aria-atomic="true">Enter a single barcode.</span>
+				#       </div>
+			
+				#       				#expect(fail-message).to eq("fail-message")
+				
+			
+			#/inner-inner-inner-describe-it-should-fail-for-these-conditions
+			#end
+		
+		#/inner-inner-describe-
+		end
+
+	end
+	
+end

--- a/spec/features/transfer_barcode_errors_spec.rb
+++ b/spec/features/transfer_barcode_errors_spec.rb
@@ -1,85 +1,85 @@
 require 'rails_helper'
 
-describe "SCSBuster transfer barcode errors" do
-  describe "When on the Transfer Barcode & Update Metadata page" do
-  
+describe 'SCSBuster transfer barcode errors' do
+  describe 'When on the Transfer Barcode & Update Metadata page' do
+
     before(:each) do
       skip_authentication_to(transfer_metadata_path)
       cut_off_sqs!
     end
 
-    describe "Given a correct bnumber and an invalid barcode is entered" do 
-      describe "non-numerical barcodes" do
-        
+    describe 'Given a correct bnumber and an invalid barcode is entered' do 
+      describe 'non-numerical barcodes' do
+
         before(:each) do
           @this_error_barcode = 'x' * 14
-          @this_error_bnumber = "b11556466x"
+          @this_error_bnumber = 'b11556466x'
         end
         
-        it "should fail non-numerical barcode with error msg" do
-          aggregate_failures "check-num" do
+        it 'should fail non-numerical barcode with error msg' do
+          aggregate_failures 'check-num' do
             find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
             find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
-            click_submit_value("submit")
+            click_submit_value('submit')
             within('#flash_error') do
-              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('must be 14 numerical digits in length')
             end
           end
         end
       end
 
-      describe  "too long barcodes" do
+      describe 'too long barcodes' do
 
         before(:each) do
           @this_error_barcode = '1' * 15
-          @this_error_bnumber = "b11556466x"
+          @this_error_bnumber = 'b11556466x'
         end
 
-        it "should fail too-long barcode with error msg" do
-          aggregate_failures "check-long" do
+        it 'should fail too-long barcode with error msg' do
+          aggregate_failures 'check-long' do
             find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
             find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
-            click_submit_value("submit")
+            click_submit_value('submit')
             within('#flash_error') do
-              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('must be 14 numerical digits in length')
             end
           end
         end
       end
 
-      describe  "short barcodes" do
+      describe 'short barcodes' do
 
         before(:each) do
           @this_error_barcode = '1' * 13
-          @this_error_bnumber = "b11556466x"
+          @this_error_bnumber = 'b11556466x'
         end
 
-        it "should fail short barcode with error msg" do
-          aggregate_failures "check-short" do
+        it 'should fail short barcode with error msg' do
+          aggregate_failures 'check-short' do
             find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
             find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
-            click_submit_value("submit")
+            click_submit_value('submit')
             within('#flash_error') do
-              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('must be 14 numerical digits in length')
             end
           end
         end
       end
 
-      describe  "empty barcodes" do
+      describe 'empty barcodes' do
 
         before(:each) do
           @this_error_barcode = ''
-          @this_error_bnumber = "b11556466x"
+          @this_error_bnumber = 'b11556466x'
         end
 
-        it "should fail empty barcode with error msg" do
-          aggregate_failures "check-short" do
+        it 'should fail empty barcode with error msg' do
+          aggregate_failures 'check-short' do
             find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
             find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
-            click_submit_value("submit")
+            click_submit_value('submit')
             within('#flash_error') do
-              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include("must be 14 numerical digits in length")
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('must be 14 numerical digits in length')
             end
           end
         end

--- a/spec/features/transfer_bnumber_errors_spec.rb
+++ b/spec/features/transfer_bnumber_errors_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+describe 'SCSBuster transfer barcode with bnumber errors' do
+	describe "When on the Transfer Barcode & Update Metadata page" do
+	
+    before(:each) do
+      skip_authentication_to(transfer_metadata_path)
+      cut_off_sqs!
+    end
+
+    describe 'Given an invalid bnumber and a correct barcode is entered' do 
+      describe 'too long bnumbers' do
+
+        before(:each) do
+          @this_error_barcode = '1' * 14
+          @this_error_bnumber = 'b' + ('1' * 9) + 'x'
+        end
+
+        it 'should fail too-long bnumber with error msg' do
+          aggregate_failures 'check-long' do
+            find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+            find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+            click_submit_value('submit')
+            within('#flash_error') do
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('the bib record number must be 10 characters long and start with "b"')
+            end
+          end
+        end
+      end
+
+      describe 'too short bnumbers' do
+
+        before(:each) do
+          @this_error_barcode = '1' * 14
+          @this_error_bnumber = 'b' + ('1' * 7) + 'x'
+        end
+
+        it 'should fail too-short bnumber with error msg' do
+          aggregate_failures 'check-short' do
+            find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+            find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+            click_submit_value('submit')
+            within('#flash_error') do
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('the bib record number must be 10 characters long and start with "b"')
+            end
+          end
+        end
+      end
+
+      describe 'empty bnumbers' do
+
+        before(:each) do
+          @this_error_barcode = '1' * 14
+          @this_error_bnumber = ''
+        end
+
+        it 'should fail empty bnumber with error msg: bib record number is blank' do
+          aggregate_failures 'check-empty' do
+            find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+            find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+            click_submit_value('submit')
+            within('#flash_error') do
+              expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('bib record number is blank')
+            end
+          end
+        end
+      end
+
+      describe 'When a malformed bnumber is entered' do
+
+        describe "starting with a wrong letter" do
+          before(:each) do
+            @this_error_barcode = '1' * 14
+            @this_error_bnumber = 'a' + ('1' * 8)
+          end
+
+          it 'should fail bnumber a11111111 with error msg' do
+            aggregate_failures 'check-start-with-a' do
+              find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+              find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+              click_submit_value('submit')
+              within('#flash_error') do
+                expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('the bib record number must be 10 characters long and start with "b"')
+              end
+            end
+          end
+        end
+
+        describe "containing all numbers" do
+          before(:each) do
+            @this_error_barcode = '1' * 14
+            @this_error_bnumber = '1' * 10
+          end
+
+          it 'should fail bnumber 1111111111 with error msg' do
+            aggregate_failures 'check-all-numbers' do
+              find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+              find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+              click_submit_value('submit')
+              within('#flash_error') do
+                expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('the bib record number must be 10 characters long and start with "b"')
+              end
+            end
+          end
+        end
+
+        describe "containing an extra letter" do
+          before(:each) do
+            @this_error_barcode = '1' * 14
+            @this_error_bnumber = 'bb' + ('1' * 8) 
+          end
+
+          it "should fail bnumber #{@this_error_bnumber} - bb11111111 with error msg" do
+            aggregate_failures 'check-extra-b' do
+              find(:xpath, "//input[@id='barcode']").set("#{@this_error_barcode}")
+              find(:xpath, "//input[@id='bib_record_number']").set("#{@this_error_bnumber}")
+              click_submit_value('submit')
+              within('#flash_error') do
+                expect((find(:xpath, "//div[@id='flash_error']/p").text).downcase).to include('the bib record number must be 10 characters long and start with "b"')
+              end
+            end
+          end
+        end
+      end
+		end
+	end
+end

--- a/spec/features/transfer_bnumber_errors_spec.rb
+++ b/spec/features/transfer_bnumber_errors_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe 'SCSBuster transfer barcode with bnumber errors' do
-	describe "When on the Transfer Barcode & Update Metadata page" do
-	
+  describe "When on the Transfer Barcode & Update Metadata page" do
+
     before(:each) do
       skip_authentication_to(transfer_metadata_path)
       cut_off_sqs!
@@ -122,6 +122,6 @@ describe 'SCSBuster transfer barcode with bnumber errors' do
           end
         end
       end
-		end
-	end
+    end
+  end
 end

--- a/spec/features/update_metadata_error_and_success_spec.rb
+++ b/spec/features/update_metadata_error_and_success_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe 'SCSBuster update metadata multi-modal errors' do
+  describe 'When on the Update SCSB Metadata page' do
+    describe 'When 2 incorrect and 8 valid barcodes are entered' do
+      before(:each) do
+        cut_off_sqs!
+        @valid_barcode = '1' * 14
+
+        skip_authentication_to(update_metadata_path)
+        fill_in('barcodes', with: "#{@valid_barcode}\n#{@valid_barcode}\n#{@valid_barcode}\n#{@valid_barcode}\n#{@valid_barcode}\n#{@valid_barcode}\n#{@valid_barcode}\n#{@valid_barcode}\n54321\n123456789012345678901\n")
+        click_submit_value('submit')
+      end
+
+      it '8 valid barcodes should display a success message' do
+        aggregate_failures 'check-newline' do
+          within('.nypl-form-success') do
+            expect(find(:xpath, "//div[@class='nypl-form-success']/p").text.downcase).to include('some barcodes were submitted')
+          end
+        end
+      end
+
+      it '2 invalid barcodes should display error messages' do
+        aggregate_failures 'check-errors' do
+          within('#flash_error') do
+            expect(find(:xpath, "//div[@id='flash_error']/p").text.downcase).to include('the barcode(s) remaining are invalid', 'each barcode must be 14 numerical digits in length', 'separate barcodes using commas or returns (new lines)')
+          end
+        end
+      end
+
+      it '2 invalid barcodes should remain in barcode field' do
+        aggregate_failures 'check-errors' do
+          expect(find(:xpath, "//div[@class='nypl-text-area-with-label'][1]/textarea[@name='barcodes']").text.downcase).to include('54321', '123456789012345678901')
+        end
+      end
+    end
+  end
+end

--- a/spec/features/update_metatada_errors_spec.rb
+++ b/spec/features/update_metatada_errors_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe 'Update metadata errors' do
+  describe 'When on the Update SCSB Metadata page' do
+    before(:each) do
+      skip_authentication_to(update_metadata_path)
+    end
+    describe 'It should fail for these conditions' do
+      it ' - non-numerical barcode (error msg: must be 14 numerical digits in length)' do
+        aggregate_failures 'check-num' do
+          fill_in('barcodes', with: 'abcdefghijklmn')
+          click_submit_value('submit')
+          within('#flash_error') do
+            expect(find(:xpath, "//div[@id='flash_error']/p").text.downcase).to include('must be 14 numerical digits in length')
+          end
+        end
+      end
+
+      it ' - too long barcode (error msg: must be 14 numerical digits in length)' do
+        aggregate_failures 'check-long' do
+          fill_in('barcodes', with: 'x' * 15)
+          click_submit_value('submit')
+          within('#flash_error') do
+            expect(find(:xpath, "//div[@id='flash_error']/p").text.downcase).to include('must be 14 numerical digits in length')
+          end
+        end
+      end
+
+      it ' - too short barcode (error msg: must be 14 numerical digits in length)' do
+        aggregate_failures 'check-short' do
+          fill_in('barcodes', with: 'x' * 13)
+          click_submit_value('submit')
+          within('#flash_error') do
+            expect(find(:xpath, "//div[@id='flash_error']/p").text.downcase).to include('the barcode(s) remaining are invalid', 'each barcode must be 14 numerical digits in length', 'separate barcodes using commas or returns (new lines)')
+          end
+        end
+      end
+
+      it ' - empty barcode (error msg: please enter one or more barcodes)' do
+        aggregate_failures 'check-short' do
+          fill_in('barcodes', with: '')
+          click_submit_value('submit')
+          within('#flash_error') do
+            expect(find(:xpath, "//div[@id='flash_error']/p").text.downcase).to include('please enter one or more barcodes')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/update_metatada_errors_spec.rb
+++ b/spec/features/update_metatada_errors_spec.rb
@@ -21,7 +21,7 @@ describe 'Update metadata errors' do
 
       it ' - too long barcode (error msg: must be 14 numerical digits in length)' do
         aggregate_failures 'check-long' do
-          fill_in('barcodes', with: 'x' * 15)
+          fill_in('barcodes', with: '1' * 15)
           click_submit_value('submit')
           within('#flash_error') do
             expect(find(:xpath, "//div[@id='flash_error']/p").text.downcase).to include('must be 14 numerical digits in length')
@@ -31,7 +31,7 @@ describe 'Update metadata errors' do
 
       it ' - too short barcode (error msg: must be 14 numerical digits in length)' do
         aggregate_failures 'check-short' do
-          fill_in('barcodes', with: 'x' * 13)
+          fill_in('barcodes', with: '1' * 13)
           click_submit_value('submit')
           within('#flash_error') do
             expect(find(:xpath, "//div[@id='flash_error']/p").text.downcase).to include('the barcode(s) remaining are invalid', 'each barcode must be 14 numerical digits in length', 'separate barcodes using commas or returns (new lines)')

--- a/spec/features/update_metatada_errors_spec.rb
+++ b/spec/features/update_metatada_errors_spec.rb
@@ -2,9 +2,12 @@ require 'rails_helper'
 
 describe 'Update metadata errors' do
   describe 'When on the Update SCSB Metadata page' do
+
     before(:each) do
       skip_authentication_to(update_metadata_path)
+      cut_off_sqs!
     end
+
     describe 'It should fail for these conditions' do
       it ' - non-numerical barcode (error msg: must be 14 numerical digits in length)' do
         aggregate_failures 'check-num' do

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -13,4 +13,29 @@ module Helpers
   def cut_off_sqs!
     allow_any_instance_of(SqsClient).to receive(:send_message) { true }
   end
+
+  def stub_refile_error_search_with(options)
+    default_options = { page: 1, total: 500, per_page: 25 }
+    options = default_options.merge(options)
+
+    results = []
+    options[:per_page].times do
+      results << { 'id' => rand(1000), 'itemBarcode' => rand(1000), 'createdDate' => random_date, 'updatedDate' => random_date, 'afMessage' => '[A message here]' }
+    end
+
+    allow_any_instance_of(RefileErrorSearch).to receive(:get_refiles) { { 'page' => options[:page], 'count' => 25, 'totalCount' => options[:total], 'data' => results } }
+  end
+
+  def last_page?
+    this_page_display = find(:xpath, "//nav[@class='nypl-results-pagination']/span[@class='page-count']").text.downcase
+    get_current_page = this_page_display.gsub(/page (\d+) of (\d+)/, '\1')
+    get_last_page = this_page_display.gsub(/page (\d+) of (\d+)/, '\2')
+    (get_current_page == get_last_page)
+  end
+
+  private
+
+  def random_date(options = { from: 2.years.ago, to: Time.now })
+    Time.at(options[:from] + rand * (options[:to].to_f - options[:from].to_f)).to_s
+  end
 end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -7,4 +7,8 @@ module Helpers
   def click_submit_value(action)
     find(:xpath, "//input[@type='submit' and translate(@value,'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')='#{action}']").click
   end
+
+  def cut_off_sqs!
+    allow_any_instance_of(SqsClient).to receive(:send_message) { true }
+  end
 end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,3 +1,5 @@
+require File.join(Rails.root, 'lib', 'sqs_client')
+
 module Helpers
   def skip_authentication_to(path)
     allow_any_instance_of(OauthController).to receive(:authenticate) { true }

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,0 +1,10 @@
+module Helpers
+  def skip_authentication_to(path)
+    allow_any_instance_of(OauthController).to receive(:authenticate) { true }
+    visit path
+  end
+
+  def click_submit_value(action)
+    find(:xpath, "//input[@type='submit' and translate(@value,'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')='#{action}']").click
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,8 +3,11 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation (or other real-world consequences) if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
+
 require 'spec_helper'
 require 'rspec/rails'
+require 'capybara/rails'
+require 'capybara/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -21,7 +24,7 @@ require 'rspec/rails'
 #
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
-RSpec.configure do |config|  
+RSpec.configure do |config|
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.
@@ -35,7 +38,7 @@ RSpec.configure do |config|
   #
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
-  # config.infer_spec_type_from_file_location!
+  config.infer_spec_type_from_file_location!
 
   # Filter lines from Rails gems in backtraces.
   # config.filter_rails_from_backtrace!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require 'spec_helper'
 require 'rspec/rails'
 require 'capybara/rails'
 require 'capybara/rspec'
+require File.join(__dir__, 'helpers')
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -25,6 +26,7 @@ require 'capybara/rspec'
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
+  config.include Helpers
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.


### PR DESCRIPTION
Hey @jbdalton 

Here are our ports of the functional tests in https://github.com/NYPL/scsbuster_functional_tests.
You've seen most of this...the only new test file I've written since last we spoke is here: https://github.com/NYPL/scsbuster/pull/21/commits/3d2940973f673d2e67b60b1f417bea44ae36c83c

It stubs the response from the refile error API to give the tests enough results to paginate through.